### PR TITLE
Update logback-classic to version 1.5.18 to fix CVE-2024-12798

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.12</version>
+            <version>1.5.18</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This PR bumps the version of logback-classic to 1.5.18 in order to fix [CVE-2024-12798](https://www.mend.io/vulnerability-database/CVE-2024-12798?utm_source=JetBrains).

<img width="641" alt="Bildschirmfoto 2025-07-07 um 21 17 25" src="https://github.com/user-attachments/assets/eb4cadce-d209-46ab-8adb-14d5bc12fc51" />
